### PR TITLE
Added support for Visual Studio 2022 Preview (and +)

### DIFF
--- a/blazor_component/blazor_component.vstemplate
+++ b/blazor_component/blazor_component.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
 	<TemplateData>
-		<Name>blazor_component</Name>
-		<Description>Blazor component with code behine file and css file</Description>
+		<Name>Blazor Component</Name>
+		<Description>Blazor component with code behind file and css file</Description>
 		<Icon>blazor_component_icon.png</Icon>
 		<TemplateID>1877733a-0e33-4634-bcb6-4ba9c5691bc6</TemplateID>
 		<ProjectType>CSharp</ProjectType>

--- a/blazor_component/blazor_vs_extensionPage.service.cs
+++ b/blazor_component/blazor_vs_extensionPage.service.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bridge.Html5;
 
-
-
 public static partial class DataService
 {
 

--- a/blazor_extension/ReleaseNote.txt
+++ b/blazor_extension/ReleaseNote.txt
@@ -1,2 +1,2 @@
-﻿2020-11-23 provide blazor component file template with code behine file and css file.
- 
+﻿2020-11-23 - chenxustu1 - Provide blazor component file template with code behine file and css file.
+2021-07-12 - KevinValmo - Add support to Visual Studio 2022 Preview

--- a/blazor_extension/source.extension.vsixmanifest
+++ b/blazor_extension/source.extension.vsixmanifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="blazor_extension.348090da-88b7-47c8-a966-44dad2825490" Version="1.0" Language="en-US" Publisher="chen xu" />
-        <DisplayName>blazor_extension</DisplayName>
+        <Identity Id="blazor_extension.348090da-88b7-47c8-a966-44dad2825490" Version="1.0.1" Language="en-US" Publisher="chen xu" />
+        <DisplayName>Blazor Component</DisplayName>
         <Description xml:space="preserve">Blazor Component Template</Description>
         <ReleaseNotes>ReleaseNote.txt</ReleaseNotes>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 18.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Main feature: added support for Visual Studio 2022 Preview.
I guess we should add `ProductArchitecture` tag to let Visual Studio install this extension.